### PR TITLE
Adding 'data' field to exported values of REST-Api export

### DIFF
--- a/imports/modules/server/dapps/export_dois.js
+++ b/imports/modules/server/dapps/export_dois.js
@@ -38,7 +38,7 @@ const exportDois = (data) => {
         { $lookup: { from: "senders", localField: "sender", foreignField: "_id", as: "SenderEmail" } },
         { $unwind: "$SenderEmail"},
         { $unwind: "$RecipientEmail"},
-        { $project: {_id:1,ownerId:1, createdAt:1, confirmedAt:1,nameId:1, 'SenderEmail.email':1,'RecipientEmail.email':1}
+        { $project: {_id:1,ownerId:1, createdAt:1, confirmedAt:1,nameId:1, 'SenderEmail.email':1,'RecipientEmail.email':1, data:1}
       }
     ];
     //if(ourData.status==1) query = {"confirmedAt": { $exists: true, $ne: null }}


### PR DESCRIPTION
The 'data' field was added to the exported opt-in values in the REST-Api export call.
This should solve https://github.com/Doichain/dapp/issues/105